### PR TITLE
Ensure boost-pad observations are properly masked

### DIFF
--- a/SkyForgeBot/necto_obs.py
+++ b/SkyForgeBot/necto_obs.py
@@ -133,7 +133,7 @@ class NectoObsBuilder:
         # Store results
         self.current_qkv = qkv / self._norm
         mask = np.zeros((1, qkv.shape[1]))
-        mask[0, 1 + len(state.players):1 + len(state.players)] = 1
+        mask[0, 1 + len(state.players):1 + len(state.players) + len(state.boost_pads)] = 1
         self.current_mask = mask
 
     def build_obs(self, player: PlayerData, state: GameState, previous_action: np.ndarray) -> Any:

--- a/tests/test_boost_pad_mask.py
+++ b/tests/test_boost_pad_mask.py
@@ -1,0 +1,55 @@
+import sys
+import types
+import pathlib
+import numpy as np
+
+# Ensure the project root is on the import path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+# Create minimal stubs for rlgym_compat modules used by necto_obs
+rlgym_compat = types.ModuleType("rlgym_compat")
+common_values = types.ModuleType("common_values")
+common_values.BLUE_TEAM = 0
+common_values.ORANGE_TEAM = 1
+game_state = types.ModuleType("game_state")
+class GameState:  # pragma: no cover - simple stub
+    pass
+class PlayerData:  # pragma: no cover - simple stub
+    pass
+game_state.GameState = GameState
+game_state.PlayerData = PlayerData
+rlgym_compat.common_values = common_values
+rlgym_compat.game_state = game_state
+sys.modules['rlgym_compat'] = rlgym_compat
+sys.modules['rlgym_compat.common_values'] = common_values
+sys.modules['rlgym_compat.game_state'] = game_state
+
+import importlib.util
+
+necto_path = pathlib.Path(__file__).resolve().parents[1] / 'SkyForgeBot' / 'necto_obs.py'
+spec = importlib.util.spec_from_file_location('necto_obs', necto_path)
+necto_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(necto_module)
+NectoObsBuilder = necto_module.NectoObsBuilder
+BOOST_LOCATIONS = necto_module.BOOST_LOCATIONS
+
+class Ball:
+    position = np.zeros(3)
+    linear_velocity = np.zeros(3)
+    angular_velocity = np.zeros(3)
+
+class DummyState:
+    def __init__(self, boost_pads):
+        self.ball = Ball()
+        self.players = []
+        self.boost_pads = boost_pads
+
+
+def test_boost_pad_mask():
+    builder = NectoObsBuilder()
+    num_boosts = len(BOOST_LOCATIONS)
+    state = DummyState(np.zeros(num_boosts))
+    builder._maybe_update_obs(state)
+    mask = builder.current_mask
+    boost_slice = mask[0, 1:1 + num_boosts]
+    assert np.all(boost_slice == 1)


### PR DESCRIPTION
## Summary
- Fix mask slice in `NectoObsBuilder` so all boost-pad entries are flagged
- Add unit test confirming boost-pad positions are included in the mask

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b688354c248323af403b2888f38917