### PR TITLE
Allow configurable model path for SkyForgeBot

### DIFF
--- a/SkyForgeBot/README.md
+++ b/SkyForgeBot/README.md
@@ -1,0 +1,16 @@
+# SkyForgeBot
+
+This package contains the RLBot implementation of SkyForgeBot.
+
+## Model selection
+
+The policy network is stored as a TorchScript file. By default the bot uses
+`necto-model.pt` shipped with this repository. To swap in a freshly trained
+model, either:
+
+* Pass the path when constructing `Agent`, e.g. `Agent("path/to/model.pt")`, or
+* Set the `SKYFORGEBOT_MODEL_PATH` environment variable, or
+* Edit `bot.cfg` and change the `model_path` under the `[Locations]` section.
+
+Relative paths in `bot.cfg` are resolved from the configuration file's
+location.

--- a/SkyForgeBot/agent.py
+++ b/SkyForgeBot/agent.py
@@ -8,10 +8,32 @@ from torch.distributions import Categorical
 
 
 class Agent:
-    def __init__(self):
+    """Wrapper around the policy network used by :class:`SkyForgeBot`.
+
+    Parameters
+    ----------
+    model_path : str, optional
+        Path to a TorchScript model to load. If ``None`` the constructor will
+        look for the ``SKYFORGEBOT_MODEL_PATH`` environment variable. When no
+        path is provided, the bundled ``necto-model.pt`` file is used. This
+        makes it easy to swap in freshly trained models without modifying the
+        source code.
+    """
+
+    def __init__(self, model_path: str | None = None):
         cur_dir = os.path.dirname(os.path.realpath(__file__))
-        with open(os.path.join(cur_dir, "necto-model.pt"), 'rb') as f:
+
+        if model_path is None:
+            model_path = os.getenv("SKYFORGEBOT_MODEL_PATH")
+
+        if model_path is None:
+            model_path = os.path.join(cur_dir, "necto-model.pt")
+        elif not os.path.isabs(model_path):
+            model_path = os.path.join(cur_dir, model_path)
+
+        with open(model_path, "rb") as f:
             self.actor = torch.jit.load(f)
+
         torch.set_num_threads(1)
 
     def act(self, state, beta):

--- a/SkyForgeBot/bot.cfg
+++ b/SkyForgeBot/bot.cfg
@@ -8,6 +8,10 @@ requirements_file = ./requirements.txt
 
 logo_file = ./logo.png
 
+# Path to the TorchScript model used by the agent. Relative paths are
+# resolved from this configuration file's directory.
+model_path = ./necto-model.pt
+
 # Name of the bot in-game
 name = SkyForgeBot
 

--- a/SkyForgeBot/bot.py
+++ b/SkyForgeBot/bot.py
@@ -1,3 +1,6 @@
+import os
+from configparser import ConfigParser
+
 import numpy as np
 import torch
 from rlbot.agents.base_agent import BaseAgent, SimpleControllerState
@@ -28,7 +31,14 @@ class SkyForgeBot(BaseAgent):
         super().__init__(name, team, index)
 
         self.obs_builder = None
-        self.agent = Agent()
+
+        model_path = os.getenv("SKYFORGEBOT_MODEL_PATH")
+        if model_path is None:
+            cfg = ConfigParser()
+            cfg.read(os.path.join(os.path.dirname(__file__), "bot.cfg"))
+            model_path = cfg.get("Locations", "model_path", fallback=None)
+
+        self.agent = Agent(model_path)
         self.tick_skip = 8
 
         # Beta controls randomness:

--- a/tests/test_agent_model_path.py
+++ b/tests/test_agent_model_path.py
@@ -1,0 +1,50 @@
+import importlib.util
+import pathlib
+import sys
+import types
+from unittest.mock import patch
+
+# Provide minimal stubs so agent.py can be imported without heavy dependencies.
+numpy_stub = types.ModuleType("numpy")
+sys.modules.setdefault("numpy", numpy_stub)
+
+torch_stub = types.ModuleType("torch")
+torch_stub.jit = types.SimpleNamespace(load=lambda f: None)
+torch_stub.set_num_threads = lambda n: None
+sys.modules.setdefault("torch", torch_stub)
+
+nn = types.ModuleType("nn")
+nn.functional = types.ModuleType("functional")
+sys.modules.setdefault("torch.nn", nn)
+sys.modules.setdefault("torch.nn.functional", nn.functional)
+
+dists = types.ModuleType("distributions")
+dists.Categorical = object
+sys.modules.setdefault("torch.distributions", dists)
+
+spec = importlib.util.spec_from_file_location(
+    "agent", pathlib.Path(__file__).resolve().parents[1] / "SkyForgeBot" / "agent.py"
+)
+agent_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(agent_module)
+Agent = agent_module.Agent
+
+
+def test_constructor_overrides_path(tmp_path):
+    model_file = tmp_path / "dummy.pt"
+    model_file.write_bytes(b"stub")
+    with patch("torch.jit.load") as mock_load:
+        Agent(model_path=str(model_file))
+        assert mock_load.call_args[0][0].name == str(model_file)
+
+
+def test_env_var_used_when_no_arg(tmp_path, monkeypatch):
+    model_file = tmp_path / "env.pt"
+    model_file.write_bytes(b"stub")
+    monkeypatch.setenv("SKYFORGEBOT_MODEL_PATH", str(model_file))
+    try:
+        with patch("torch.jit.load") as mock_load:
+            Agent()
+            assert mock_load.call_args[0][0].name == str(model_file)
+    finally:
+        monkeypatch.delenv("SKYFORGEBOT_MODEL_PATH", raising=False)


### PR DESCRIPTION
## Summary
- allow `Agent` to load a TorchScript model from a provided path or `SKYFORGEBOT_MODEL_PATH`
- expose `model_path` in `bot.cfg` and wire it through `bot.py`
- document model swapping and add tests for path selection

## Testing
- `pytest tests/test_agent_model_path.py -q`
- `pytest -q` *(fails: AttributeError: module 'numpy' has no attribute 'array')*
- `pip install numpy torch --extra-index-url https://download.pytorch.org/whl/cpu` *(fails: Cannot connect to proxy.)*

------
https://chatgpt.com/codex/tasks/task_e_68b68b487918832384f102b8a75dedd5