### PR TITLE
Align training export with RLBot model path

### DIFF
--- a/training/train.py
+++ b/training/train.py
@@ -72,9 +72,12 @@ def main():
     actor = AgentActor(model.policy, env.action_space)
     dummy = torch.zeros((1,) + env.observation_space.shape)
     scripted = torch.jit.trace(actor, dummy)
+
+    # Save directly to the path expected by RLBot so the new model is
+    # loaded without any manual renaming or moving.
     out_dir = os.path.join(os.path.dirname(__file__), "..", "SkyForgeBot")
     os.makedirs(out_dir, exist_ok=True)
-    scripted.save(os.path.join(out_dir, "trained-model.pt"))
+    scripted.save(os.path.join(out_dir, "necto-model.pt"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- save trained TorchScript actor to `SkyForgeBot/necto-model.pt`
- ensure RLBot configuration continues to load the latest model automatically

## Testing
- `python training/train.py` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b692f2e5e083239f0d9b1f93a60ef6