### PR TITLE
Update RLBot and rlgym dependencies

### DIFF
--- a/SkyForgeBot/requirements.txt
+++ b/SkyForgeBot/requirements.txt
@@ -1,9 +1,10 @@
 # Include everything the framework requires
 # You will automatically get updates for all versions starting with "1.".
-rlbot==1.*
+rlbot==5.*
 --find-links https://download.pytorch.org/whl/torch_stable.html
 torch==2.0.1+cpu
-rlgym-compat==1.0.2
+rlgym-compat>=2.0
+rlgym>=2.0
 numpy
 
 # This will cause pip to auto-upgrade and stop scaring people with warning messages


### PR DESCRIPTION
## Summary
- Bump RLBot dependency to the 5.x series
- Require rlgym-compat 2.x and add rlgym 2.x

## Testing
- `pip install -r SkyForgeBot/requirements.txt` *(fails: Could not find a version that satisfies rlbot==5.*, rlgym-compat>=2.0)*
- `pip install rlgym>=2.0 --pre` *(passes)*
- `python training/train.py` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68b6935f334083238b35caba36f7f382