### PR TITLE
Fix RLBot imports and add RLBot project folder

### DIFF
--- a/SkyForgeBot/bot.py
+++ b/SkyForgeBot/bot.py
@@ -7,8 +7,8 @@ from rlbot.agents.base_agent import BaseAgent, SimpleControllerState
 from rlbot.utils.structures.game_data_struct import GameTickPacket
 from rlgym_compat import GameState
 
-from .agent import Agent
-from .necto_obs import NectoObsBuilder
+from agent import Agent
+from necto_obs import NectoObsBuilder
 
 KICKOFF_CONTROLS = (
         11 * 4 * [SimpleControllerState(throttle=1, boost=True)]

--- a/rlbot/rlbot.cfg
+++ b/rlbot/rlbot.cfg
@@ -1,0 +1,10 @@
+[RLBot Configuration]
+# Configuration for running SkyForgeBot with RLBot.
+
+[Match Configuration]
+num_participants = 1
+
+[Participants]
+participant_config_0 = ../SkyForgeBot/bot.cfg
+participant_team_0 = 0
+participant_bot_skill_0 = 1.0


### PR DESCRIPTION
## Summary
- Use absolute imports in SkyForgeBot to avoid relative import errors in RLBot
- Add an `rlbot` folder with a simple match configuration for running SkyForgeBot

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6a0cfd48c832398f042e1aeec1ee9