### PR TITLE
Wire RLGym session into training environment

### DIFF
--- a/src/rlbot_integration/controller_adapter.py
+++ b/src/rlbot_integration/controller_adapter.py
@@ -1,20 +1,32 @@
 from __future__ import annotations
 import numpy as np
 
-# Continuous: steer, throttle, pitch, yaw, roll
+# Continuous inputs: steer, throttle, pitch, yaw, roll
 CONT_DIM = 5
 # Discrete/binary: jump, boost, handbrake
 DISC_DIM = 3
 
 
+def apply_cont(a):
+    # [-1,1] already; just clamp for safety
+    return np.clip(a, -1.0, 1.0).astype(np.float32)
+
+
+def apply_disc(b):
+    return (b > 0.5).astype(np.float32)
+
+
 def format_action(a_cont: np.ndarray, a_disc: np.ndarray) -> np.ndarray:
     """Return merged action vector expected by RLBot.
 
-    Continuous controls are squashed with tanh into [-1, 1]; discrete logits or
-    probabilities are thresholded at >0 to produce {0,1} outputs.
+    Output order matches the RLGym session packer:
+    [throttle, steer, pitch, yaw, roll, jump, boost, handbrake].
     """
-    cont = np.tanh(np.asarray(a_cont, dtype=np.float32))
-    disc = (np.asarray(a_disc, dtype=np.float32) > 0).astype(np.float32)
-    return np.concatenate([cont[:CONT_DIM], disc[:DISC_DIM]])
+    cont = apply_cont(np.asarray(a_cont, dtype=np.float32))
+    disc = apply_disc(np.asarray(a_disc, dtype=np.float32))
+    steer, throttle, pitch, yaw, roll = cont[:CONT_DIM]
+    jump, boost, handbrake = disc[:DISC_DIM]
+    return np.array([throttle, steer, pitch, yaw, roll, jump, boost, handbrake], dtype=np.float32)
 
-__all__ = ["CONT_DIM", "DISC_DIM", "format_action"]
+
+__all__ = ["CONT_DIM", "DISC_DIM", "apply_cont", "apply_disc", "format_action"]

--- a/src/training/rlgym_session.py
+++ b/src/training/rlgym_session.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+from dataclasses import dataclass
+import numpy as np
+
+# RLGym v2 / RocketSim imports (adapt to your installed API)
+# If your package exposes different entrypoints, adjust here only.
+from rlgym.envs import Match
+from rlgym.sim import make_default_ball, make_default_cars, SimState
+from rlgym.utils.state_setters import DefaultState
+from rlgym.utils.terminal_conditions import GoalScoredCondition, TimeoutCondition
+from rlgym.utils.reward_functions.common_rewards import EventReward  # baseline; we’ll ignore and use SSLReward
+from rlgym.utils import common_values as C
+
+
+# ---- small utility container for actions for TWO controlled cars ----
+@dataclass
+class TwoActions:
+    # continuous: [steer, throttle, pitch, yaw, roll] per car
+    cont0: np.ndarray  # shape (5,)
+    cont1: np.ndarray  # shape (5,)
+    # discrete: [jump, boost, handbrake] per car (0/1)
+    disc0: np.ndarray  # shape (3,)
+    disc1: np.ndarray  # shape (3,)
+
+
+class RLSession2v2:
+    """
+    Wrap an RLGym v2 Match (2v2) with helpers:
+      - reset(seed) -> state dict
+      - step(a_cont: (10,), a_disc: (6,)) -> state dict
+    We always control BLUE team’s two players (indices 0,1).
+    """
+
+    def __init__(self, tick_skip: int = 8, game_speed: float = 1.0, episode_len_seconds: int = 300):
+        self.tick_skip = tick_skip
+        self.game_speed = game_speed
+        self.episode_len_seconds = episode_len_seconds
+        self._build_match()
+
+    def _build_match(self):
+        # cars: 2 blue (our hivemind-controlled copies), 2 orange (self-play opponents)
+        self.match = Match(
+            tick_skip=self.tick_skip,
+            team_size=2,
+            state_setter=DefaultState(),
+            terminal_conditions=[GoalScoredCondition(), TimeoutCondition(self.episode_len_seconds)],
+            reward_function=EventReward(),  # placeholder; we compute SSLReward outside
+            obs_builder=None,               # we build obs ourselves
+            game_speed=self.game_speed,
+        )
+        self._time = 0.0
+
+    # ---- public API expected by env_factory.py ----
+    def reset(self, seed: int | None = None) -> dict:
+        if seed is not None:
+            np.random.seed(seed)
+        self.match.reset(seed=seed)
+        self._time = 0.0
+        return self._telemetry()
+
+    def step(self, a: TwoActions) -> dict:
+        # Convert our action heads to RLGym controller arrays for both blue cars.
+        # RLGym expects per-player inputs typically in the order:
+        # throttle, steer, pitch, yaw, roll, jump, boost, handbrake  (all floats/bools)
+        def pack(cont, disc):
+            steer, throttle, pitch, yaw, roll = cont.astype(np.float32)
+            j, b, hb = (disc > 0.5).astype(np.float32)
+            return np.array([throttle, steer, pitch, yaw, roll, j, b, hb], dtype=np.float32)
+
+        blue0 = pack(a.cont0, a.disc0)
+        blue1 = pack(a.cont1, a.disc1)
+
+        # Opponent policy (self-play baseline): mirror with mild noise or zero controllers
+        # You can swap this for a scripted/Nexto-like baseline later.
+        orange0 = np.zeros(8, np.float32)
+        orange1 = np.zeros(8, np.float32)
+
+        actions = [blue0, blue1, orange0, orange1]
+        done = self.match.step(actions)
+        self._time += self.tick_skip / 120.0  # 120Hz sim when possible
+        return self._telemetry(done=done)
+
+    # ---- telemetry shaping for rewards + obs ----
+    def _telemetry(self, done: bool = False) -> dict:
+        state: SimState = self.match.get_state()  # ball & car kinematics
+        ball = state.ball  # position, vel, etc.
+        cars = state.cars  # list of 4 cars; 0,1 blue; 2,3 orange
+
+        def car_blob(i):
+            c = cars[i]
+            return dict(
+                pos=c.position.copy(),
+                vel=c.linear_velocity.copy(),
+                ang=c.angular_velocity.copy(),
+                rot=c.rotation.copy(),          # euler or quaternion depending on API
+                airborne=bool(c.on_ground == 0),
+                has_flip=bool(c.has_jump),
+                boost=float(c.boost),
+                supersonic=bool(c.supersonic),
+            )
+
+        # events (fill simple defaults now; env reward will compute precise ones if you add detectors)
+        events = dict(
+            goal=bool(self.match._goal_scored if hasattr(self.match, "_goal_scored") else False),
+            save=False,
+            shot_on_target=False,
+            clear_to_corner=False,
+            demo_for=False,
+            demo_against=False,
+            mercy=False,
+            time_up=done,
+        )
+
+        team = dict(both_challenging=False)  # can be computed from ETAs later
+        touch = dict(by_self=False)
+        combo = dict(double_tap=False, flip_reset=False)
+
+        return dict(
+            time=self._time,
+            ball_pos=ball.position.copy(),
+            ball_vel=ball.linear_velocity.copy(),
+            ball_ang=ball.angular_velocity.copy(),
+            self=car_blob(0),         # we define “self” as blue car index 0; obs builder will include teammate
+            mate=car_blob(1),
+            opp0=car_blob(2),
+            opp1=car_blob(3),
+            event=events,
+            team=team,
+            touch=touch,
+            combo=combo,
+        )


### PR DESCRIPTION
## Summary
- add RLSession2v2 wrapper around RLGym 2.0 for 2v2 self-play
- integrate session into RL2v2Env and delegate telemetry/observation building
- align controller adapter with session action mapping and thresholding

## Testing
- `python -c "import torch, gymnasium; print('torch', torch.__version__, 'cuda', torch.cuda.is_available()); print('gymnasium', gymnasium.__version__)"`
- `PYTHONPATH=. pytest tests/test_obs_contract.py tests/test_action_contract.py -q`
- `python -m src.training.train_v2 --envs 2 --steps 50000 --ckpt_dir models/checkpoints --tensorboard runs/ssl_v2` *(failed: ModuleNotFoundError: No module named 'rlgym.envs')*
- `python -m src.inference.export --sb3 --ckpt models/checkpoints/best_sb3.zip --out models/exported/ssl_policy.ts --obs_dim 107` *(failed: FileNotFoundError: models/checkpoints/best_sb3.zip.zip)*
- `python run.py --config rlbot\match_nexto.toml` *(failed: can't open file '/workspace/The-Ender/run.py')*

------
https://chatgpt.com/codex/tasks/task_e_68b6a7f7fc9883238c9170c92d90de20