### PR TITLE
Add rlgym-compat dependency for training

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ packaging the bot for RLBot Championship submissions.
    ```bash
    pip install -r SkyForgeBot/requirements.txt
    ```
-3. (Optional) For training, also install:
+3. (Optional) For training, install the additional dependencies:
    ```bash
-   pip install stable-baselines3
+   pip install -r env/requirements.txt
    ```
 
 ## Training new weights

--- a/SkyForgeBot/requirements.txt
+++ b/SkyForgeBot/requirements.txt
@@ -3,7 +3,7 @@
 rlbot==5.*
 --find-links https://download.pytorch.org/whl/torch_stable.html
 torch==2.0.1+cpu
-rlgym-compat>=2.0
+rlgym-compat>=1.1.0,<2.0
 rlgym>=2.0
 numpy
 # This will cause pip to auto-upgrade and stop scaring people with warning messages

--- a/env/requirements.txt
+++ b/env/requirements.txt
@@ -14,6 +14,7 @@ shimmy==1.3.0
 
 # RLGym v2 + sim
 rlgym==2.0.0
+rlgym-compat==1.1.0
 rocketsim==4.5.0
 
 # RL


### PR DESCRIPTION
## Summary
- add rlgym-compat to training requirements
- correct runtime requirements to valid version range
- document training dependency installation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6b78d8b788323ab025336cb39ba83