### PR TITLE
Fix RLBot requirement

### DIFF
--- a/env/requirements.txt
+++ b/env/requirements.txt
@@ -21,4 +21,4 @@ rocketsim==4.5.0
 stable-baselines3==2.3.2
 
 # RLBot v5 (already present; keep pin you use)
-git+https://github.com/RLBot/RLBot.git@develop
+rlbot==1.68.0


### PR DESCRIPTION
## Summary
- use rlbot 1.68.0 from PyPI instead of non-existent `develop` branch

## Testing
- `pip install -r env/requirements.txt` *(fails: No matching distribution found for rocketsim==4.5.0)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b747e879f4832391897edc81c43130