### PR TITLE
Update dependency pins for Python 3.10

### DIFF
--- a/SkyForgeBot/requirements.txt
+++ b/SkyForgeBot/requirements.txt
@@ -1,8 +1,8 @@
 # Include everything the framework requires
 # You will automatically get updates for all versions starting with "1.".
-rlbot==5.*
---find-links https://download.pytorch.org/whl/torch_stable.html
-torch==2.0.1+cpu
+rlbot==1.68.0
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch==2.3.1+cpu
 rlgym-compat>=1.1.0,<2.0
 rlgym>=2.0
 numpy

--- a/env/requirements.txt
+++ b/env/requirements.txt
@@ -15,10 +15,10 @@ shimmy==1.3.0
 # RLGym v2 + sim
 rlgym==2.0.0
 rlgym-compat==1.1.0
-rocketsim==4.5.0
+rocketsim==2.1.1
 
 # RL
 stable-baselines3==2.3.2
 
-# RLBot v5 (already present; keep pin you use)
+# RLBot framework
 rlbot==1.68.0


### PR DESCRIPTION
## Summary
- pin rlbot to 1.68.0 and use torch 2.3.1+cpu from the pytorch CPU index
- replace non-existent rocketsim 4.5.0 with rocketsim 2.1.1

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b74a245bcc83239df60466686c0fc2